### PR TITLE
feature/#5 : 파일 사이즈를 이용한 수집 진행 여부 확인 로직 추가

### DIFF
--- a/avro/src/main/java/gleaners/avro/download_target.avsc
+++ b/avro/src/main/java/gleaners/avro/download_target.avsc
@@ -5,6 +5,8 @@
   "fields": [
     { "name": "pipeId", "type": "string" },
     { "name": "url", "type": "string" },
-    { "name": "token", "type": "string" }
+    { "name": "token", "type": "string" },
+    { "name": "prevFileSize", "type": "long" },
+    { "name": "minAllowanceRate", "type": "int" }
   ]
 }

--- a/downloader/src/test/java/gleaners/usecase/DownloadTaskTest.java
+++ b/downloader/src/test/java/gleaners/usecase/DownloadTaskTest.java
@@ -1,7 +1,6 @@
 package gleaners.usecase;
 
 import gleaners.avro.DownloadTarget;
-import gleaners.port.ProductSender;
 import gleaners.support.ReactiveKafkaIntegrationTests;
 import lombok.extern.log4j.Log4j2;
 import okhttp3.mockwebserver.MockResponse;
@@ -54,7 +53,7 @@ class DownloadTaskTest extends ReactiveKafkaIntegrationTests {
 
 //        DownloadTask downloadTask = new DownloadTask(productSender, downloader);
 
-        DownloadTarget downloadTarget = new DownloadTarget("1", "https://www.naver.com", "test-token");
+        DownloadTarget downloadTarget = new DownloadTarget("1", "https://www.naver.com", "test-token", -1L, 0);
 
 
 //        downloadTask

--- a/downloader/src/test/java/gleaners/usecase/DownloaderTest.java
+++ b/downloader/src/test/java/gleaners/usecase/DownloaderTest.java
@@ -12,7 +12,7 @@ class DownloaderTest {
     void downloadServiceTest() {
         Downloader downloader = new Downloader();
 
-        DownloadTarget downloadTarget = new DownloadTarget("1", "http://httpstat.us/200", null);
+        DownloadTarget downloadTarget = new DownloadTarget("1", "http://httpstat.us/200", null, -1L, 0);
 
         StepVerifier.create(downloader.extractLineByDelimiter(downloadTarget))
             .thenConsumeWhile(response -> response.contains("200 OK"))


### PR DESCRIPTION
Trigger에서 보내준 파일 사이즈 ( 이전 수집 파일 사이즈 ) 와 header 의 content-length를 비교하여 수집 여부를 결정한다.
해당 로직은 전체 EP 상에서만 실행되어야하는 로직인데 아직 전체/요약에 대한 타입을 나누지 않아서 무조건 사이즈 비교하는 방식으로 구현되어있다.