### PR TITLE
feature/#52 : 카프카 스키마 레지스트리 네이밍 전략 변경

### DIFF
--- a/avro/build.gradle.kts
+++ b/avro/build.gradle.kts
@@ -28,13 +28,13 @@ schemaRegistry {
     quiet.set(false)
 
     register.subject(
-            "gleaners.avro.Product",
+            "download-product-value",
             "avro/src/main/java/gleaners/avro/product.avsc",
             "AVRO"
     )
 
     register.subject(
-            "gleaners.avro.DownloadTarget",
+            "download-target-value",
             "avro/src/main/java/gleaners/avro/download_target.avsc",
             "AVRO")
 

--- a/downloader/src/main/java/gleaners/infrastructure/kafka/KafkaTopicProperties.java
+++ b/downloader/src/main/java/gleaners/infrastructure/kafka/KafkaTopicProperties.java
@@ -1,0 +1,14 @@
+package gleaners.infrastructure.kafka;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public record KafkaTopicProperties(
+        @Value("${spring.kafka.consumer.topic}")
+        String receiverTopic,
+        @Value("${spring.kafka.producer.topic}")
+        String senderTopic
+) {
+}

--- a/downloader/src/main/java/gleaners/port/DownloadTargetReceiver.java
+++ b/downloader/src/main/java/gleaners/port/DownloadTargetReceiver.java
@@ -21,10 +21,10 @@ public class DownloadTargetReceiver {
     private static final int MAX_ATTEMPTS = 3;
     private static final Duration MIN_BACKOFF = Duration.ofSeconds(2);
 
-    private final ReactiveKafkaConsumerTemplate<Integer, DownloadTarget> receiver;
+    private final ReactiveKafkaConsumerTemplate<String, DownloadTarget> receiver;
     private final DownloadTask downloadTask;
 
-    public DownloadTargetReceiver(ReactiveKafkaConsumerTemplate<Integer, DownloadTarget> receiver, DownloadTask downloadTask) {
+    public DownloadTargetReceiver(ReactiveKafkaConsumerTemplate<String, DownloadTarget> receiver, DownloadTask downloadTask) {
         this.receiver = receiver;
         this.downloadTask = downloadTask;
 
@@ -43,7 +43,7 @@ public class DownloadTargetReceiver {
                 .subscribe();
     }
 
-    private Mono<ReceiverRecord<Integer, DownloadTarget>> handleOnError(Throwable error) {
+    private Mono<ReceiverRecord<String, DownloadTarget>> handleOnError(Throwable error) {
         ReceiverRecordException ex = (ReceiverRecordException) error.getCause();
 
         log.error("Retries exhausted for : {}", ex.getRecord().value());
@@ -55,7 +55,7 @@ public class DownloadTargetReceiver {
         return Mono.empty();
     }
 
-    private Consumer<ReceiverRecord<Integer, DownloadTarget>> processReceiveMessage() {
+    private Consumer<ReceiverRecord<String, DownloadTarget>> processReceiveMessage() {
         return receiverRecord -> {
             ReceiverOffset offset = receiverRecord.receiverOffset();
 

--- a/downloader/src/main/java/gleaners/port/ProductSender.java
+++ b/downloader/src/main/java/gleaners/port/ProductSender.java
@@ -1,6 +1,7 @@
 package gleaners.port;
 
 import gleaners.avro.Product;
+import gleaners.infrastructure.kafka.KafkaTopicProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate;
@@ -11,9 +12,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProductSender {
     private final ReactiveKafkaProducerTemplate<String, Product> downloadSender;
+    private final KafkaTopicProperties topicProperties;
 
     public void send(Product product) {
-        downloadSender.send("test-after-download", product)
+        downloadSender.send(topicProperties.senderTopic(), product)
             .doOnSuccess(senderResult ->
                     log.info("send : {} \n offset : {}", product, senderResult.recordMetadata().offset()))
             .subscribe();

--- a/downloader/src/main/resources/application.yml
+++ b/downloader/src/main/resources/application.yml
@@ -21,7 +21,6 @@ spring:
       on-profile: local
 
   kafka:
-    topic: test
     bootstrap-servers: localhost:9092
     properties:
       schema:
@@ -29,9 +28,11 @@ spring:
           url: http://localhost:8085
 
     producer:
+      topic: download-product
       acks: -1
 
     consumer:
+      topic: download-target
       group-id: reactive_consumer_group
       enable-auto-commit: false
       auto-commit-interval: 10


### PR DESCRIPTION
- application.yml : 프로듀서/컨슈머 토픽을 관리하게끔 토픽 네임 추가하여 KafkaTopicProperties로 관리한다.
- KafkaConfig : RecordNameStrategy -> TopicNameStrategy 변경에 대한 대응 작업
- avro/build.gradle.kts : TopicNameStrategy에 대응하기 위해서 subject명 변경

### 공유 사항 

`TopicNameStrategy` : 이 전략은 **{토픽명}-key 혹은 {토픽명}-value**로 등록된 스키마를 사용하는 전략입니다. 

e.g) 토픽 명 : test일 경우, 스키마레지스트리에 등록되는 스키마 subject는 test-value 혹은 키값이면 test-key 이런식으로 등록됩니다.

또한, 컨슈머에서 AVRO Deserialize할 시에 `Kafka : ClassCastException: class org.apache.avro.generic.GenericData$Record cannot be cast to class` 와 같은 에러가 발생할 수 있는데 이는 카프카가 기본적으로 AVRO 역직렬화를 `GenericRecord`로 설정하기 때문입니다. 

이에, 컨슈머쪽에서는 `consumerProps.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, true);` 와 같은 설정이 필요합니다. 

### 관련 이슈 
#52 
